### PR TITLE
Support for Laravel 5.8 (fire method renamed to dispatch)

### DIFF
--- a/src/Traits/EventTrait.php
+++ b/src/Traits/EventTrait.php
@@ -122,7 +122,7 @@ trait EventTrait
             return;
         }
 
-        $method = $halt ? 'until' : 'fire';
+        $method = $halt ? 'until' : method_exists($dispatcher, 'fire') ? 'fire' : 'dispatch';
 
         return $dispatcher->{$method}($event, $payload);
     }

--- a/tests/Traits/EventTraitTest.php
+++ b/tests/Traits/EventTraitTest.php
@@ -55,15 +55,8 @@ class EventTraitTest extends PHPUnit_Framework_TestCase
 
         $dispatcher = m::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        if (method_exists($dispatcher, 'fire'))
-        {
-            $dispatcher->shouldReceive('fire')->once();
-        }
-        else
-        {
-            $dispatcher->shouldReceive('dispatch')->once();
-        }
-
+        $method = method_exists($dispatcher, 'fire') ? 'fire' : 'dispatch';
+        $dispatcher->shouldReceive($method)->once();
 
         $eventTrait->setDispatcher($dispatcher);
 

--- a/tests/Traits/EventTraitTest.php
+++ b/tests/Traits/EventTraitTest.php
@@ -55,7 +55,15 @@ class EventTraitTest extends PHPUnit_Framework_TestCase
 
         $dispatcher = m::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $dispatcher->shouldReceive('fire')->once();
+        if (method_exists($dispatcher, 'fire'))
+        {
+            $dispatcher->shouldReceive('fire')->once();
+        }
+        else
+        {
+            $dispatcher->shouldReceive('dispatch')->once();
+        }
+
 
         $eventTrait->setDispatcher($dispatcher);
 


### PR DESCRIPTION
Since Laravel 5.4 the fire method was deprecated and renamed to dispatch, on Laravel 5.8 the fire method was removed:

https://github.com/cartalyst/support/issues/5
https://laravel.com/docs/master/upgrade